### PR TITLE
Enable yamllint

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -2,7 +2,9 @@
 
 name: ansible lint
 
-on: [push, pull_request]
+on:  # noqa yaml
+  - push
+  - pull_request
 
 jobs:
   lint:
@@ -12,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install dependencies
-        run: pip3 install ansible ansible-lint
+        run: pip3 install ansible ansible-lint yamllint
 
       - name: lint playbook
         run: ansible-lint


### PR DESCRIPTION
While yamllint is used by ansible-lint, it is not automatically
installed when you install ansible-lint.