### PR TITLE
Test with molecule instead of ansible-lint

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -1,6 +1,6 @@
 ---
 
-name: ansible lint
+name: ansible tests
 
 on:  # noqa yaml
   - push
@@ -14,7 +14,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install dependencies
-        run: pip3 install ansible ansible-lint yamllint
+        run: >
+          pip3 install
+          ansible
+          ansible-lint
+          yamllint
+          molecule
+          molecule-docker
+          molecule-podman
 
-      - name: lint playbook
-        run: ansible-lint
+      - name: test playbook
+        run: molecule test --driver-name docker

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -2,7 +2,7 @@
 
 name: ansible tests
 
-on:  # noqa yaml
+on:  # yamllint disable-line rule:truthy
   - push
   - pull_request
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,5 @@
+---
+
 galaxy_info:
   role_name: loki
   author: Timo Nogueira Brockmeyer

--- a/tasks/install_loki.yml
+++ b/tasks/install_loki.yml
@@ -37,7 +37,9 @@
         loki_checksum: "{{ item.split(' ')[0] }}"
       with_items: "{{ _checksums }}"
       when: "'loki-linux-amd64.zip' in item"
-  when: loki_remote_version["failed"] or loki_remote_version["content"] | b64decode != json_reponse.json.tag_name
+  when: >
+    loki_remote_version["failed"]
+    or loki_remote_version["content"] | b64decode != json_reponse.json.tag_name
 
 - name: download and install loki
   block:
@@ -79,7 +81,9 @@
         owner: loki
         group: loki
         mode: '0644'
-  when: loki_remote_version["failed"] or loki_remote_version["content"] | b64decode != json_reponse.json.tag_name
+  when: >
+    loki_remote_version["failed"]
+    or loki_remote_version["content"] | b64decode != json_reponse.json.tag_name
   notify: restart loki
 
 - name: copy service file

--- a/tasks/install_promtail.yml
+++ b/tasks/install_promtail.yml
@@ -60,7 +60,10 @@
         promtail_checksum: "{{ item.split(' ')[0] }}"
       with_items: "{{ _checksums }}"
       when: "'promtail-linux-amd64.zip' in item"
-  when: promtail_remote_version["failed"] or promtail_remote_version["content"] | b64decode != json_reponse.json.tag_name
+  when: >
+    promtail_remote_version["failed"]
+    or promtail_remote_version["content"] | b64decode
+    != json_reponse.json.tag_name
 
 - name: download and install promtail
   block:
@@ -102,7 +105,10 @@
         owner: promtail
         group: promtail
         mode: '0644'
-  when: promtail_remote_version["failed"] or promtail_remote_version["content"] | b64decode != json_reponse.json.tag_name
+  when: >
+    promtail_remote_version["failed"]
+    or promtail_remote_version["content"] | b64decode
+    != json_reponse.json.tag_name
   notify: restart promtail
 
 - name: copy service file


### PR DESCRIPTION
This patch switches from ansible-lint to running mulecule for testing
the ansible script since we have molecule tests and a molecule test run
includes ansible-lint.